### PR TITLE
Este merge adiciona a funcionalidade de redefinição de senha por e-mail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-oauth2-client</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/prati/projeto/redeSocial/config/SecurityConfig.java
+++ b/src/main/java/prati/projeto/redeSocial/config/SecurityConfig.java
@@ -14,7 +14,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import prati.projeto.redeSocial.modal.entity.CustomOAuth2User;
 import prati.projeto.redeSocial.security.JwtAuthenticationFilter;
 import prati.projeto.redeSocial.security.JwtService;
-import prati.projeto.redeSocial.service.CustomOAuth2UserService;
+import prati.projeto.redeSocial.service.auth.CustomOAuth2UserService;
 
 @EnableWebSecurity
 @Configuration

--- a/src/main/java/prati/projeto/redeSocial/config/SwaggerConfig.java
+++ b/src/main/java/prati/projeto/redeSocial/config/SwaggerConfig.java
@@ -3,28 +3,44 @@ package prati.projeto.redeSocial.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
-import io.swagger.v3.oas.models.security.SecurityRequirement;
-import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.*;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
+
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
                 .info(new Info()
                         .title("Back-End: Libris")
-                        .description("API destinada ao gerenciamento de uma rede social para entusiastas de literatura. Esta API oferece recursos para autenticação de usuários, gerenciamento de perfis personalizados, interações sociais e compartilhamento de informações relacionadas ao universo literário. Desenvolvida para promover a conexão entre leitores e o engajamento em uma comunidade dedicada aos livros.")
+                        .description("PI destinada ao gerenciamento de uma rede social para entusiastas de literatura. Esta API oferece recursos para autenticação de usuários, gerenciamento de perfis personalizados, interações sociais e compartilhamento de informações relacionadas ao universo literário. Desenvolvida para promover a conexão entre leitores e o engajamento em uma comunidade dedicada aos livros.")
                         .version("1.0")
-                       ).components(new Components()
+                )
+                .components(new Components()
                         .addSecuritySchemes("bearerAuth",
                                 new SecurityScheme()
                                         .type(SecurityScheme.Type.HTTP)
                                         .scheme("bearer")
-                                        .bearerFormat("JWT")))
-                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
+                                        .bearerFormat("JWT"))
+                        .addSecuritySchemes("OAuth2",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.OAUTH2)
+                                        .flows(new OAuthFlows()
+                                                .authorizationCode(new OAuthFlow()
+                                                        .authorizationUrl("http://localhost:8080/oauth2/authorization/google")
+                                                        .tokenUrl("https://oauth2.googleapis.com/token")
+                                                        .scopes(new Scopes()
+                                                                .addString("email", "Acesso ao email do usuário")
+                                                                .addString("profile", "Acesso ao perfil do usuário"))
+                                                )
+                                        )
+                        )
+                )
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+                .addSecurityItem(new SecurityRequirement().addList("OAuth2"));
     }
 
     @Bean

--- a/src/main/java/prati/projeto/redeSocial/modal/entity/ResetPasswordRequest.java
+++ b/src/main/java/prati/projeto/redeSocial/modal/entity/ResetPasswordRequest.java
@@ -1,0 +1,18 @@
+package prati.projeto.redeSocial.modal.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Schema(description = "Entidade que representa a solicitação de redefinição de senha.")
+public class ResetPasswordRequest {
+
+    @NotEmpty(message = "O e-mail não pode ser vazio.")
+    @Email(message = "O e-mail fornecido é inválido.")
+    @Schema(description = "E-mail cadastrado do usuário para envio do token de redefinição", example = "usuario@example.com")
+    private String email;
+}

--- a/src/main/java/prati/projeto/redeSocial/modal/entity/Usuario.java
+++ b/src/main/java/prati/projeto/redeSocial/modal/entity/Usuario.java
@@ -40,5 +40,10 @@ public class Usuario {
     @Schema(description = "Indica se o usuário é administrador", example = "false")
     private boolean admin = false;
 
+    @Schema(description = "Provedor de autenticação do usuário", example = "google")
     private String authProvider;
+
+    @Column(name = "reset_token", length = 2000)
+    @Schema(description = "Token para redefinição de senha", example = "abc123xyz")
+    private String resetToken;
 }

--- a/src/main/java/prati/projeto/redeSocial/rest/controller/O2authController.java
+++ b/src/main/java/prati/projeto/redeSocial/rest/controller/O2authController.java
@@ -26,7 +26,7 @@ public class O2authController {
                                                     @RequestParam String refreshToken) {
         logger.info("Token recebido no endpoint /oauth2/success: " + token);
 
-        if (token == null || token.isEmpty()) {
+        if (token == null || token.isEmpty() || refreshToken == null || refreshToken.isEmpty()) {
             logger.error("Token ausente ou vazio.");
             return new ServiceResponse<>(null, "Token ausente ou vazio", false, getFormattedTimestamp());
         }

--- a/src/main/java/prati/projeto/redeSocial/rest/controller/UsuarioController.java
+++ b/src/main/java/prati/projeto/redeSocial/rest/controller/UsuarioController.java
@@ -10,7 +10,10 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import prati.projeto.redeSocial.modal.entity.ResetPasswordRequest;
 import prati.projeto.redeSocial.modal.entity.Usuario;
+import prati.projeto.redeSocial.repository.UsuarioRepository;
+import prati.projeto.redeSocial.rest.dto.ResetPasswordDTO;
 import prati.projeto.redeSocial.rest.dto.UsuarioResumidoDTO;
 import prati.projeto.redeSocial.rest.response.ServiceResponse;
 import prati.projeto.redeSocial.service.UsuarioService;
@@ -93,6 +96,50 @@ public class UsuarioController {
         usuarioService.updateUsuario(email, usuario);
         UsuarioResumidoDTO usuarioResumido = new UsuarioResumidoDTO(usuario.getUsername(), usuario.getEmail());
         return new ServiceResponse<>(usuarioResumido, "Usuário atualizado com sucesso", true, getFormattedTimestamp());
+    }
+
+    @Operation(
+            summary = "Solicitar mudança de senha",
+            description = "Envia um e-mail com um link para redefinir a senha.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "E-mail enviado com sucesso",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ServiceResponse.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "404", description = "Usuário não encontrado")
+            }
+    )
+    @PostMapping("/reset-password")
+    @ResponseStatus(HttpStatus.OK)
+    public ServiceResponse<String> requestPasswordReset(@RequestBody ResetPasswordRequest request) {
+        usuarioService.requestPasswordReset(request.getEmail());
+        return new ServiceResponse<>(null,"E-mail enviado com sucesso", true, getFormattedTimestamp());
+    }
+
+
+    @Operation(
+            summary = "Confirmar redefinição de senha",
+            description = "Redefine a senha do usuário utilizando um token válido.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Senha redefinida com sucesso",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ServiceResponse.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "400", description = "Token inválido ou expirado")
+            }
+    )
+    @PostMapping("/reset-password/confirm")
+    public ServiceResponse<String> resetPassword(@RequestBody ResetPasswordDTO resetPasswordDTO) {
+        usuarioService.resetPassword(resetPasswordDTO.getToken(), resetPasswordDTO.getNewPassword());
+        return new ServiceResponse<>(null,"Senha redefinida com sucesso", true, getFormattedTimestamp());
     }
 
     private String getFormattedTimestamp() {

--- a/src/main/java/prati/projeto/redeSocial/rest/dto/ResetPasswordDTO.java
+++ b/src/main/java/prati/projeto/redeSocial/rest/dto/ResetPasswordDTO.java
@@ -1,0 +1,20 @@
+package prati.projeto.redeSocial.rest.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Schema(description = "Objeto que representa a confirmação de redefinição de senha.")
+public class ResetPasswordDTO {
+
+    @NotEmpty(message = "O token não pode estar vazio.")
+    @Schema(description = "Token de redefinição de senha enviado por e-mail", example = "abcd1234xyz")
+    private String token;
+
+    @NotEmpty(message = "A nova senha não pode estar vazia.")
+    @Schema(description = "Nova senha escolhida pelo usuário", example = "novaSenha123")
+    private String newPassword;
+}

--- a/src/main/java/prati/projeto/redeSocial/security/JwtAuthenticationFilter.java
+++ b/src/main/java/prati/projeto/redeSocial/security/JwtAuthenticationFilter.java
@@ -11,7 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import prati.projeto.redeSocial.exception.TokenInvalidException;
-import prati.projeto.redeSocial.service.CustomUserDetailsService;
+import prati.projeto.redeSocial.service.auth.CustomUserDetailsService;
 
 import java.io.IOException;
 

--- a/src/main/java/prati/projeto/redeSocial/security/JwtService.java
+++ b/src/main/java/prati/projeto/redeSocial/security/JwtService.java
@@ -63,6 +63,18 @@ public class JwtService {
                 .compact();
     }
 
+    public String criarTokenEmail(String subject, Duration duracao) {
+        LocalDateTime dataHoraExpiracao = LocalDateTime.now().plus(duracao);
+        Instant instant = dataHoraExpiracao.atZone(ZoneId.systemDefault()).toInstant();
+        Date data = Date.from(instant);
+
+        return Jwts.builder()
+                .setSubject(subject)
+                .setExpiration(data)
+                .signWith(rsaKeyProvider.getPrivateKey())
+                .compact();
+    }
+
     public boolean tokenValido(String token) {
         try {
             Claims claims = obterClaims(token);

--- a/src/main/java/prati/projeto/redeSocial/service/UsuarioService.java
+++ b/src/main/java/prati/projeto/redeSocial/service/UsuarioService.java
@@ -43,4 +43,22 @@ public interface UsuarioService {
      * @throws RegraNegocioException Caso o usuário não seja encontrado ou tente alterar o nome de usuário.
      */
     void updateUsuario(String email, Usuario usuario);
+
+    /**
+     * Gera e envia um token para redefinição de senha ao email do usuário.
+     *
+     * @param email O email do usuário que solicitou a redefinição de senha.
+     * @throws RegraNegocioException Caso o usuário não seja encontrado no sistema.
+     */
+    void requestPasswordReset(String email);
+
+    /**
+     * Redefine a senha do usuário com base em um token de redefinição válido.
+     *
+     * @param token O token gerado para a redefinição de senha.
+     * @param newPassword A nova senha escolhida pelo usuário.
+     * @throws TokenInvalidException Caso o token seja inválido ou tenha expirado.
+     * @throws RegraNegocioException Caso o usuário correspondente ao token não seja encontrado.
+     */
+    void resetPassword(String token, String newPassword);
 }

--- a/src/main/java/prati/projeto/redeSocial/service/auth/CustomOAuth2UserService.java
+++ b/src/main/java/prati/projeto/redeSocial/service/auth/CustomOAuth2UserService.java
@@ -1,4 +1,4 @@
-package prati.projeto.redeSocial.service;
+package prati.projeto.redeSocial.service.auth;
 
 import lombok.AllArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import prati.projeto.redeSocial.modal.entity.CustomOAuth2User;
 import prati.projeto.redeSocial.modal.entity.Usuario;
 import prati.projeto.redeSocial.repository.UsuarioRepository;
+import prati.projeto.redeSocial.service.UsuarioService;
 
 @AllArgsConstructor
 @Service
@@ -30,6 +31,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService{
             novoUsuario.setUsername(generateUsername(name, email));
             novoUsuario.setSenha(null);
             novoUsuario.setAuthProvider("google");
+            novoUsuario.setAdmin(false);
             return usuarioService.saveUsuario(novoUsuario);
         });
 

--- a/src/main/java/prati/projeto/redeSocial/service/auth/CustomUserDetailsService.java
+++ b/src/main/java/prati/projeto/redeSocial/service/auth/CustomUserDetailsService.java
@@ -1,4 +1,4 @@
-package prati.projeto.redeSocial.service;
+package prati.projeto.redeSocial.service.auth;
 
 import lombok.AllArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/prati/projeto/redeSocial/service/email/EmailService.java
+++ b/src/main/java/prati/projeto/redeSocial/service/email/EmailService.java
@@ -1,0 +1,21 @@
+package prati.projeto.redeSocial.service.email;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+
+    @Autowired
+    private JavaMailSender mailSender;
+
+    public void sendEmail(String to, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(text);
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/prati/projeto/redeSocial/service/impl/UsuarioServiceImpl.java
+++ b/src/main/java/prati/projeto/redeSocial/service/impl/UsuarioServiceImpl.java
@@ -4,10 +4,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import prati.projeto.redeSocial.config.PasswordConfig;
 import prati.projeto.redeSocial.exception.RegraNegocioException;
+import prati.projeto.redeSocial.exception.TokenInvalidException;
 import prati.projeto.redeSocial.modal.entity.Usuario;
 import prati.projeto.redeSocial.repository.UsuarioRepository;
 import prati.projeto.redeSocial.rest.dto.UsuarioResumidoDTO;
+import prati.projeto.redeSocial.security.JwtService;
+import prati.projeto.redeSocial.service.email.EmailService;
 import prati.projeto.redeSocial.service.UsuarioService;
+
+import java.time.Duration;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +20,9 @@ public class UsuarioServiceImpl implements UsuarioService{
 
     private final PasswordConfig passwordConfig;
     private final UsuarioRepository usuarioRepository;
+    private final EmailService emailService;
+    private final JwtService jwtService;
+
 
     @Override
     public UsuarioResumidoDTO getUsuarioByEmail(String email) {
@@ -58,5 +66,37 @@ public class UsuarioServiceImpl implements UsuarioService{
         usuarioExistente.setSenha(senhaCriptografada);
 
         usuarioRepository.save(usuarioExistente);
+    }
+
+    @Override
+    public void requestPasswordReset(String email) {
+        Usuario usuario = usuarioRepository.findByEmail(email)
+                .orElseThrow(() -> new RegraNegocioException("Usuário não encontrado"));
+
+        String token = jwtService.criarTokenEmail(email, Duration.ofHours(1));
+
+        usuario.setResetToken(token);
+        usuarioRepository.save(usuario);
+
+        String resetLink = "http://seusite.com/reset-password?token=" + token;
+        String emailText = "Clique no link para redefinir sua senha: " + resetLink;
+        emailService.sendEmail(email, "Redefinição de Senha", emailText);
+    }
+
+    @Override
+    public void resetPassword(String token, String newPassword) {
+        if (!jwtService.tokenValido(token)) {
+            throw new TokenInvalidException("Token inválido ou expirado");
+        }
+
+        String email = jwtService.obterLoginUsuario(token);
+
+        Usuario usuario = usuarioRepository.findByEmail(email)
+                .orElseThrow(() -> new RegraNegocioException("Usuário não encontrado"));
+
+        String senhaCriptografada = passwordConfig.passwordEncoder().encode(newPassword);
+        usuario.setSenha(senhaCriptografada);
+        usuario.setResetToken(null);
+        usuarioRepository.save(usuario);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,15 @@ spring.profiles.active=dev
 spring.security.oauth2.client.registration.google.client-id=CLIENT_ID
 spring.security.oauth2.client.registration.google.client-secret=CLIENT_SECRET
 spring.security.oauth2.client.registration.google.scope=profile,email
-spring.security.oauth2.client.registration.google.redirect-uri=SEU_REDIRECT
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
+
+# Configurações do servidor de e-mail (Gmail)
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=USERNAME
+spring.mail.password=PASSWORD
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
 
 jwt.expiration=2h
 jwt.refresh.expiration=7d


### PR DESCRIPTION
Novas entidades: ResetPasswordRequest e ResetPasswordDTO.

Serviço de e-mail (EmailService) para envio de links de redefinição de senha.

Endpoints:
- POST /auth/reset-password: Solicita redefinição de senha.
- POST /auth/reset-password/confirm: Confirma redefinição de senha com token válido.

Atualizações na entidade Usuario para suportar tokens de redefinição.

Reorganização de pastas:
- Serviços de autenticação movidos para a pasta auth.
- Serviço de e-mail movido para a pasta email.

Ajustes na documentação do Swagger e da entidade Usuario.